### PR TITLE
Decrement internal WaitGroup during Done()

### DIFF
--- a/multierrgroup.go
+++ b/multierrgroup.go
@@ -1,8 +1,9 @@
 package multierrgroup
 
 import (
-	"github.com/hashicorp/go-multierror"
 	"sync"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 // WaitGroup waits for a collection of goroutines to finish.
@@ -39,6 +40,7 @@ func (g *WaitGroup) Add(delta int) {
 
 // Done decrements the WaitGroup counter by one and adds err to the collected errors.
 func (g *WaitGroup) Done(err error) {
+	defer g.wg.Add(-1)
 	g.mu.Lock()
 	defer g.mu.Unlock()
 

--- a/multierrgroup_test.go
+++ b/multierrgroup_test.go
@@ -1,0 +1,24 @@
+package multierrgroup_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/jribe/multierrgroup"
+)
+
+func TestCompletion(t *testing.T) {
+	wg := &multierrgroup.WaitGroup{}
+
+	wg.Add(2)
+	go func() {
+		wg.Done(nil)
+	}()
+	go func() {
+		wg.Done(nil)
+	}()
+
+	if err := wg.Wait(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
The documentation for `Done()` suggests that the WaitGroup counter is decremented. This change updates the code to be consistent with the comment and fixes a bug that could cause indefinite blocking.